### PR TITLE
Files as output

### DIFF
--- a/host_app/__main__.py
+++ b/host_app/__main__.py
@@ -1,6 +1,5 @@
 #from .app import create_app, teardown_zeroconf
 import os
-import threading
 
 # Have to setup environment variables before importing flask app
 os.environ.setdefault("FLASK_APP", "host_app")

--- a/host_app/flask_app/app.py
+++ b/host_app/flask_app/app.py
@@ -803,7 +803,7 @@ def fetch_modules(modules) -> list[ModuleConfig]:
             filepath.write(res_bin.content)
 
         # Add other listed files related to the module.
-        data_files = []
+        data_files = {}
         for key, res_other in res_others.items():
             other_path = module_mount_path(module["name"], key)
 
@@ -811,7 +811,8 @@ def fetch_modules(modules) -> list[ModuleConfig]:
             with open(other_path, 'wb') as filepath:
                 filepath.write(res_other.content)
 
-            data_files.append(other_path)
+            # Map the mount name to whatever path the actual file is at.
+            data_files[key] = other_path
 
             # update the module configuration with the model path
             # TODO: Does having a "model path" attribute in the module

--- a/host_app/flask_app/app.py
+++ b/host_app/flask_app/app.py
@@ -175,7 +175,9 @@ def do_wasm_work(entry: RequestEntry):
         return this_result
 
     headers = next_call.headers
-    files = next_call.files
+    # NOTE: IIUC this matches how 'requests' documentation instructs to do for
+    # multi-file uploads, so I'm guessing it closes the opened files once done.
+    files = { p: open(f, "rb") for p, f in next_call.files.items() }
 
     sub_response = getattr(requests, next_call.method)(
         next_call.url,
@@ -557,9 +559,9 @@ def run_module_function_raw_input(module_name, function_name):
 
     return jsonify({ 'result': result })
 
-@bp.route('/foo')
-def serve_test_jpg():
-    return send_file('../temp_image.jpg')
+@bp.route('/debug/<module_name>/<filename>')
+def serve_test_jpg(module_name: str, filename: str):
+    return send_file(module_mount_path(module_name, filename))
 
 @bp.route('/ml/<module_name>', methods=['POST'])
 def run_ml_module(module_name = None):

--- a/host_app/utils/__init__.py
+++ b/host_app/utils/__init__.py
@@ -1,0 +1,13 @@
+"""
+Common utilities.
+"""
+
+FILE_TYPES = [
+    "image/png",
+    "image/jpeg",
+    "image/jpg",
+    "application/octet-stream"
+]
+"""
+Media types of files that are supported in requests.
+"""

--- a/host_app/utils/deployment.py
+++ b/host_app/utils/deployment.py
@@ -6,18 +6,20 @@ This module defines the Deployment and CallData classes.
 
 from dataclasses import dataclass, field
 from functools import reduce
+from itertools import chain
 import json
 from pathlib import Path
 from typing import Any, Dict, Tuple, Set
 
 from host_app.wasm_utils.wasm_api import ModuleConfig, WasmModule, WasmRuntime, WasmType
 from host_app.utils import FILE_TYPES
-from host_app.utils.endpoint import EndpointRequest, EndpointResponse, Endpoint, Schema, SchemaType
+from host_app.utils.endpoint import EndpointResponse, Endpoint, Schema, SchemaType
 from host_app.utils.mount import MountStage, MountPathFile
 
 
 EndpointArgs = str | list[str] | dict[str, Any] | None
-EndpointData = list[Path] | None
+EndpointData = list[str] | None
+"""List of mount names that the module defines as outputs of a ran function"""
 EndpointOutput = Tuple[EndpointArgs, EndpointData]
 
 @dataclass
@@ -26,7 +28,7 @@ class CallData:
     url: str
     headers: dict[str, str]
     method: str
-    files: dict[str, Any]
+    files: list[str] | None
 
     @classmethod
     def from_endpoint(
@@ -41,7 +43,7 @@ class CallData:
         '''
 
         # TODO: Fill in URL path.
-        target_url = endpoint.url.rstrip('/')
+        target_url = endpoint.url.rstrip('/') + endpoint.path
 
         # Fill in URL query.
         if args:
@@ -51,14 +53,14 @@ class CallData:
                 # NOTE: Only one parameter is supported for now (WebAssembly currently
                 # does not seem to support tuple outputs (easily)). Also path should
                 # have been already filled and provided in the deployment phase.
-                param_name = endpoint.parameters[0]["name"]
+                param_name = endpoint.request.parameters[0]["name"]
                 param_value = args
                 query = f'?{param_name}={param_value}'
             elif isinstance(args, list):
                 # Build the query in order.
                 query = reduce(
                     lambda acc, x: f'{acc}&{x[0]}={x[1]}',
-                    zip(map(lambda y: y["name"], endpoint.parameters), args),
+                    zip(map(lambda y: y["name"], endpoint.request.parameters), args),
                     '?'
                 )
             elif isinstance(args, dict):
@@ -74,9 +76,8 @@ class CallData:
             target_url += query
 
         headers = {}
-        files = endpoint.get_request_body_files()
 
-        return cls(target_url, headers, endpoint.method, files)
+        return cls(target_url, headers, endpoint.method, files or {})
 
 @dataclass
 class FunctionLink:
@@ -101,6 +102,11 @@ a deployment can not have two modules with the same name.
 FunctionLinkMap = dict[str, FunctionLink]
 ModuleLinkMap = dict[str, dict[FunctionLinkMap]]
 
+MountPathMap = dict[str, MountPathFile]
+MountStageMap = dict[MountStage, list[MountPathMap]]
+FunctionMountMap = dict[str, MountStageMap]
+ModuleMountMap = dict[str, FunctionMountMap]
+
 @dataclass
 class Deployment:
     '''
@@ -108,25 +114,42 @@ class Deployment:
     WebAssembly functions and vice versa.
     '''
     id: str # pylint: disable=invalid-name
-    runtime: WasmRuntime
+    runtimes: dict[str, WasmRuntime]
     _modules: list[ModuleConfig]
     endpoints: ModuleEndpointMap
     _instructions: dict[str, Any]
+    _mounts: dict[str, Any]
     modules: dict[str, ModuleConfig] = field(init=False)
     instructions: ModuleLinkMap = field(init=False)
+    mounts: ModuleMountMap = field(init=False)
 
     def __post_init__(self):
+        # Map the modules by their names for easier access.
         self.modules = { m.name: m for m in self._modules }
 
         # Make the received whatever data into objects at runtime because of
-        # dynamic typing.
-        for module_id, functions in self.endpoints.items():
+        # dynamic typing. NOTE/FIXME: This is mutating the collection while
+        # iterating it which might be bad...
+        # Endpoints:
+        for module_name, functions in self.endpoints.items():
             for function_name, endpoint in functions.items():
-                self.endpoints[module_id][function_name] = Endpoint(**endpoint)
+                self.endpoints[module_name][function_name] = Endpoint(**endpoint)
+        # Mounts:
+        self.mounts = {}
+        for module_name, functions in self._mounts.items():
+            self.mounts[module_name] = {}
+            for function_name, stage_mounts in functions.items():
+                self.mounts[module_name][function_name] = {}
+                for stage, mounts in stage_mounts.items():
+                    # NOTE: There might be duplicate paths in the mounts.
+                    self.mounts[module_name][function_name][MountStage(stage)] = \
+                        [MountPathFile(**mount) for mount in mounts]
 
-        # NOTE: This is what current implementation sends as instructions which
-        # might change to not have the 'module' key at all.
+        # Build how function calls are chained or linked to each other across
+        # endpoints and other devices.
         self.instructions = {}
+        # NOTE: This is what current implementation sends as instructions which
+        # might change to not have the 'modules' key at all.
         for module_name, functions in self._instructions['modules'].items():
             self.instructions[module_name] = {}
             for function_name, link in functions.items():
@@ -144,118 +167,31 @@ class Deployment:
         # prevent unnecessary network requests.
         return self.instructions[module_name][function_name].to
 
-    def mounts_for(self, module_id, function_name) -> dict[MountStage, Set[dict[str, str]]]:
-        '''
-        Grouped by the mount stage, get the sets of files to be mounted for the
-        module's function and whether they are mandatory or not.
-        '''
-
-        # TODO: When the component model is to be integrated, map arguments in
-        # request to the interface described in .wit.
-
-        request: EndpointRequest = self.endpoints[module_id][function_name].request
-        if request.request_body and request.request_body.media_type == 'multipart/form-data':
-            request_body_paths = (
-                MountPathFile.list_from_multipart(
-                    request.request_body,
-                    stage=MountStage.EXECUTION
-                )
-            )
-        else:
-            # Only multipart/form-data is supported for file mounts.
-            request_body_paths = []
-
-        # Check that all the expected media types are supported.
-        # TODO: Could be done at deployment time.
-        found_unsupported_medias = list(filter(
-            lambda x: x.media_type not in FILE_TYPES, request_body_paths
-        ))
-        if found_unsupported_medias:
-            raise NotImplementedError(f'Input file types not supported: "{found_unsupported_medias}"')
-
-        # Get a list of expected file parameters. The 'name' is actually
-        # interpreted as a path relative to module root.
-        param_files = [
-            (
-                MountPathFile(
-                    str(parameter['name']), 'application/octet-stream', MountStage.EXECUTION
-                ),
-                bool(parameter.get('required', False))
-            )
-            for parameter in request.parameters
-            if parameter.get('in', None) == 'requestBody'
-                and parameter.get('name', '') != ''
-        ]
-
-        # All 'pathed' files are required by default.
-        request_body_paths = list(map(
-            lambda x: (x, True),
-            request_body_paths
-        ))
-
-        # Lastly if the _response_ contains files, the matching filepaths need
-        # to be made available for the module to write as well.
-        response: EndpointResponse = self.endpoints[module_id][function_name].response
-        if response.media_type == 'multipart/form-data':
-            response_files = (
-                MountPathFile.list_from_multipart(
-                    response.response_body,
-                    stage=MountStage.OUTPUT
-                )
-            )
-        else:
-            # Only multipart/form-data is supported for file mounts.
-            response_files = []
-
-        mounts = param_files + request_body_paths + response_files
-
-        # TODO: Use groupby instead of this triple-set-threat.
-        execution_stage_mount_paths: Set[str] = set(
-            filter(
-                lambda y: y[0].stage == MountStage.EXECUTION,
-                mounts
-            )
-        )
-        deployment_stage_mount_paths: Set[str] = set(
-            filter(
-                lambda y: y[0].stage == MountStage.DEPLOYMENT,
-                mounts
-            )
-        )
-        output_stage_mount_paths: Set[str] = set(
-            filter(
-                lambda y: y[0].stage == MountStage.OUTPUT,
-                mounts
-            )
-        )
-
-        return {
-           MountStage.EXECUTION: execution_stage_mount_paths,
-           MountStage.DEPLOYMENT: deployment_stage_mount_paths,
-           MountStage.OUTPUT: output_stage_mount_paths,
-        }
-
     def _connect_request_files_to_mounts(
-            self,
-            module: WasmModule,
-            function_name,
-            request_filepaths: dict[str, Path]
+        self,
+        module_name,
+        function_name,
+        request_filepaths: dict[str, Path]
     ) -> None:
         """
-        Check the validity of and set up the given mounts for the module to use
-        based on files found in request.
+        Check the validity of file mounts received in request. Set _all_ mounts
+        up for the module to use for this function.
+
+        The setup is needed, because received files in requests are saved into
+        some arbitrary filesystem locations, where they need to be moved from
+        for the Wasm module to access.
         """
-        mounts = self.mounts_for(module.id, function_name)
-        deployment_stage_mount_paths = mounts[MountStage.EXECUTION]
+        mounts: MountStageMap = self.mounts[module_name][function_name]
+        deployment_stage_mount_paths = mounts[MountStage.DEPLOYMENT]
         execution_stage_mount_paths = mounts[MountStage.EXECUTION]
 
         # Map all kinds of file parameters (optional or required) to expected
         # mount paths and actual files _once_.
         # NOTE: Assuming the deployment filepaths have been handled already.
-        received_filepaths: Set[str] = set(map(lambda x: x.mount_path, deployment_stage_mount_paths))
-        for request_mount_path, temp_path in request_filepaths.items():
+        received_filepaths: Set[str] = set(map(lambda x: x.path, deployment_stage_mount_paths))
+        for request_mount_path, temp_source_path in request_filepaths.items():
             # Check that the file is expected.
-            if request_mount_path not in map(lambda x: x.mount_path, execution_stage_mount_paths):
+            if request_mount_path not in map(lambda x: x.path, execution_stage_mount_paths):
                 raise RuntimeError(f'Unexpected input file "{request_mount_path}"')
 
             # Check that the file is not already mapped. NOTE: This prevents
@@ -263,13 +199,17 @@ class Deployment:
             if request_mount_path not in received_filepaths:
                 received_filepaths.add(request_mount_path)
             else:
-                raise RuntimeError(f'Input file "{temp_path}" already mapped to "{request_mount_path}"')
+                raise RuntimeError(f'Input file "{temp_source_path}" already mapped to "{request_mount_path}"')
 
         # Get the paths of _required_ files.
-        required_input_mount_paths: Set[str] = set(filter(
-            lambda x: x.required,
-            deployment_stage_mount_paths | execution_stage_mount_paths
+        required_input_mount_paths: Set[str] = set(map(
+            lambda y: y.path,
+            filter(
+                lambda x: x.required,
+                chain(deployment_stage_mount_paths, execution_stage_mount_paths)
+            )
         ))
+
         # Check that required files have been correctly received. Output paths
         # are not expected in request at all.
         required_but_not_mounted = required_input_mount_paths - received_filepaths
@@ -278,27 +218,30 @@ class Deployment:
 
         # Set up _all_ the files needed for this run, remapping expected mount
         # paths to temporary paths and then moving the contents between them.
-        all_mounts = execution_stage_mount_paths | deployment_stage_mount_paths | mounts[MountStage.OUTPUT]
+        all_mounts = chain(execution_stage_mount_paths, deployment_stage_mount_paths, mounts[MountStage.OUTPUT])
         for mount in all_mounts:
-            # Search for the actual filepath in filesystem first from request
-            # (execution) and second from module config (deployment).
-            if temp_path := request_filepaths.get(
-                mount.mount_path,
-                module.get_mount(mount.mount_path)
-            ):
-                # FIXME: Importing here to avoid circular imports.
-                from host_app.flask_app.app import module_mount_path
-                host_path = module_mount_path(module.name, mount.mount_path)
-                if host_path != temp_path:
-                    with open(host_path, "wb") as mountpath:
-                        with open(temp_path, "rb") as datapath:
-                            mountpath.write(datapath.read())
-                else:
-                    print('File already at mount location:', host_path)
+            temp_source_path = None
+            match mount.stage:
+                case MountStage.DEPLOYMENT:
+                    temp_source_path = self.modules[module_name].data_files.get(mount.path, None)
+                case MountStage.EXECUTION:
+                    temp_source_path = request_filepaths.get(mount.path, None)
+                case MountStage.OUTPUT:
+                    continue
+
+            if not temp_source_path:
+                print(f'Module expects mount "{mount.path}", but it was not found in request or deployment.')
+                raise RuntimeError(f'Missing input file "{mount.path}"')
+
+            # FIXME: Importing here to avoid circular imports.
+            from host_app.flask_app.app import module_mount_path
+            host_path = module_mount_path(module_name, mount.path)
+            if host_path != temp_source_path:
+                with open(host_path, "wb") as mountpath:
+                    with open(temp_source_path, "rb") as datapath:
+                        mountpath.write(datapath.read())
             else:
-                print(f'Module expects mount "{mount.mount_path}", but it was not found in request or deployment.')
-
-
+                print('File already at mount location:', host_path)
 
     def prepare_for_running(
         self,
@@ -316,11 +259,12 @@ class Deployment:
             1. The instantiated module.
             2. Ordered arguments for the function.
 
-        :param app_context_module_mount_path: Function for getting the path to module's mount path based on Flask app's config.
+        :param app_context_module_mount_path: Function for getting the path to
+        module's mount path based on Flask app's config.
         '''
         # Initialize the module.
         module_config = self.modules[module_name]
-        module = self.runtime.get_or_load_module(module_config)
+        module = self.runtimes[module_name].get_or_load_module(module_config)
         if module is None:
             raise RuntimeError("Wasm module could not be loaded!")
 
@@ -331,7 +275,7 @@ class Deployment:
 
         # Get the mounts described for this module for checking requirementes
         # and mapping to actual received files in this request.
-        self._connect_request_files_to_mounts(module, function_name, request_filepaths)
+        self._connect_request_files_to_mounts(module.name, function_name, request_filepaths)
 
         return module, primitive_args
 
@@ -354,24 +298,26 @@ class Deployment:
 
         # NOTE: Assuming the actual method used was the one described in
         # deployment.
-        source_endpoint_result = self.parse_endpoint_result(
-            module_name, function_name, wasm_output
+        next_exec_args, next_exec_files = self.parse_endpoint_result(
+            wasm_output,
+            self.endpoints[module_name][function_name].response,
+            self.mounts[module_name][function_name][MountStage.OUTPUT]
         )
 
         # Check if there still is stuff to do.
         if (next_endpoint := self._next_target(module_name, function_name)):
             next_call = CallData.from_endpoint(
-                next_endpoint, *source_endpoint_result
+                next_endpoint, next_exec_args, next_exec_files
             )
-            return source_endpoint_result, next_call
+            return (next_exec_args, next_exec_files), next_call
 
-        return source_endpoint_result, None
+        return (next_exec_args, next_exec_files), None
 
     def parse_endpoint_result(
             self,
-            module_name,
-            function_name,
-            func_result,
+            wasm_output,
+            response_endpoint: EndpointResponse,
+            output_mounts: dict[str, MountPathFile]
         ) -> EndpointOutput:
         '''
         Based on media type (and schema if a structure like JSON), transform given
@@ -388,17 +334,17 @@ class Deployment:
         .
         '''
 
-        from_endpoint: EndpointResponse = self.instructions[module_name][function_name].from_.response
-
-        if from_endpoint.media_type == 'application/json':
-            if can_be_represented_as_wasm_primitive(from_endpoint.schema):
-                return json.dumps(func_result), None
+        if response_endpoint.media_type == 'application/json':
+            if can_be_represented_as_wasm_primitive(response_endpoint.schema):
+                return json.dumps(wasm_output), None
             raise NotImplementedError('Non-primitive JSON from Wasm output not supported yet')
-        if from_endpoint.media_type in FILE_TYPES:
+        if response_endpoint.media_type in FILE_TYPES:
             # The result is expected to be found in a file mounted to the module.
-            out_img_path = self.modules[module_name].get_output_path()
-            return None, out_img_path
-        raise NotImplementedError(f'Unsupported response media type "{from_endpoint.media_type}"')
+            assert len(output_mounts) == 1, \
+                f'One and only one output file expected for media type "{response_endpoint.media_type}"'
+            out_img_name = output_mounts[0].path
+            return None, [out_img_name]
+        raise NotImplementedError(f'Unsupported response media type "{response_endpoint.media_type}"')
 
 def can_be_represented_as_wasm_primitive(schema: Schema) -> bool:
     '''

--- a/host_app/utils/deployment.py
+++ b/host_app/utils/deployment.py
@@ -347,7 +347,6 @@ class Deployment:
 
         # Set up _all_ the files needed for this run, remapping expected mount
         # paths to temporary paths and then moving the contents between them.
-        print(module_config)
         for mount, _required in mounts:
             # Search for the actual filepath in filesystem first from request
             # (execution) and second from module config (deployment).
@@ -356,9 +355,12 @@ class Deployment:
                 module_config.data_files.get(mount.mount_path, None)
             ):
                 host_path = app_context_module_mount_path(module_name, mount.mount_path)
-                with open(host_path, "wb") as mountpath:
-                    with open(temp_path, "rb") as datapath:
-                        mountpath.write(datapath.read())
+                if host_path != temp_path:
+                    with open(host_path, "wb") as mountpath:
+                        with open(temp_path, "rb") as datapath:
+                            mountpath.write(datapath.read())
+                else:
+                    print(f'File already at mount location:', host_path)
             else:
                 print(f'Module expects mount "{mount.mount_path}", but it was not found in request or deployment.')
 

--- a/host_app/utils/deployment.py
+++ b/host_app/utils/deployment.py
@@ -1,120 +1,28 @@
 '''
-Utilities for intepreting application deployments based on (OpenAPI) descriptions
-of "things" (i.e., WebAssembly services/functions on devices) and executing
-their instructions.
+This module defines the Deployment and CallData classes.
+- Deployment interprets the instructions for how to link two WebAssembly functions together.
+- CallData contains the data needed for then actually calling a remote function's endpoint.
 '''
 
 from dataclasses import dataclass, field
-from enum import Enum
 from functools import reduce
 import json
 from pathlib import Path
 from typing import Any, Dict, Tuple, Set
 
-from host_app.wasm_utils.wasm_api import WasmRuntime, WasmModule, ModuleConfig, WasmType
+from host_app.wasm_utils.wasm_api import ModuleConfig, WasmModule, WasmRuntime, WasmType
+from host_app.utils import FILE_TYPES
+from host_app.utils.endpoint import EndpointRequest, EndpointResponse, Endpoint, Schema, SchemaType
+from host_app.utils.mount import MountStage, MountPathFile
 
-
-FILE_TYPES = [
-    "image/png",
-    "image/jpeg",
-    "image/jpg",
-    "application/octet-stream"
-]
-"""
-Media types that are considered files in chaining requests and thus will be
-sent with whatever the sender (requests-library) decides.
-"""
-
-class MountStage(Enum):
-    '''
-    Defines the stage at which a file is mounted.
-    '''
-    DEPLOYMENT = 'deployment'
-    EXECUTION = 'execution'
-    OUTPUT = 'output'
-
-@dataclass(eq=True, frozen=True)
-class MountPathFile:
-    '''
-    Defines the schema used for files in "multipart/form-data" requests
-    '''
-    mount_path: str
-    media_type: str
-    # HACK: This default stage is here because of the current implementation
-    # being clumsy to get module stage...
-    stage: MountStage = MountStage.EXECUTION
-    encoding: str = 'base64'
-    type: str = 'string'
-
-    MediaTypeObject = dict[str, Any]
-
-    @classmethod
-    def list_from_multipart(cls, multipart: dict[str, Any]): # -> list[MountPathFile]:
-        '''
-        Extract list of files to mount when multipart/form-data is used to
-        describe a schema of multiple files.
-
-        Create a MountPathFiles from the JSON schema used in this project for
-        describing files and their paths.
-        '''
-        schema = multipart['schema']
-        assert schema['type'] == 'object', 'Only object schemas supported'
-        assert schema['properties'], 'No properties defined for multipart schema'
-
-        mounts = []
-        for path, schema in get_supported_file_schemas(multipart):
-            media_type = multipart['encoding'][path]['contentType']
-            # NOTE: The other encoding field ('format') is not regarded here.
-            mount = cls(path, media_type)
-            mounts.append(mount)
-
-        return mounts
 
 EndpointArgs = str | list[str] | dict[str, Any] | None
-EndpointData = str | bytes | Path | None
+EndpointData = list[Path] | None
 EndpointOutput = Tuple[EndpointArgs, EndpointData]
 
 @dataclass
-class Endpoint:
-    '''Describing an endpoint for a RPC-call'''
-    url: str
-    method: str
-    parameters: list[dict[str, str | bool]]
-    response_media_obj: Tuple[str, dict[str, Any] | None]
-    request_media_obj: Tuple[str, dict[str, Any] | None] | None = None
-
-    @classmethod
-    def from_openapi(cls, description: dict[str, Any]):
-        '''
-        Create an Endpoint object from an endpoint's (partly OpenAPI v3.1.0 path
-        item object) description.
-        '''
-        path = description['path']
-        target_method, operation_obj = validate_operation(
-            description['operation']['method'], description['operation']['body']
-        )
-        response_media = get_main_response_content_entry(operation_obj)
-
-        # Select specific media type based on the possible _input_ to this
-        # endpoint (e.g., if this endpoint can receive a JPEG-image).
-        request_media = None
-        if (rbody := operation_obj.get('requestBody', None)):
-            # NOTE: The first media type is selected.
-            request_media = assert_single_pop(rbody['content'].items())
-
-        url = description['url'].rstrip('/') + path
-
-        return cls(
-            url,
-            target_method,
-            operation_obj['parameters'],
-            (response_media[0], response_media[1].get('schema', None)),
-            request_media
-        )
-
-@dataclass
 class CallData:
-    '''Minimal stuff needed for calling an endpoint'''
+    '''Endpoint with matching arguments and other request data (files)'''
     url: str
     headers: dict[str, str]
     method: str
@@ -125,7 +33,7 @@ class CallData:
         cls,
         endpoint: Endpoint,
         args: EndpointArgs = None,
-        data: EndpointData = None
+        files: EndpointData = None
     ):
         '''
         Fill in the parameters and input for an endpoint with arguments and
@@ -166,78 +74,96 @@ class CallData:
             target_url += query
 
         headers = {}
-        files = {}
-        if endpoint.request_media_obj:
-            headers = { 'Content-Type': endpoint.request_media_obj[0] }
-            if endpoint.request_media_obj[0] == 'multipart/form-data':
-                execution_files = list(filter(
-                    lambda x: MountStage(x[1]['stage']) == MountStage.EXECUTION,
-                    get_supported_file_schemas(endpoint.request_media_obj[1])
-                ))
-                # Map the mount names to files created during previous Wasm
-                # call.
-                for path, _schema in execution_files:
-                    # NOTE: Only one file is expected in output.
-                    files[path] = data
-            else:
-                headers['Content-Type'] = endpoint.request_media_obj[0]
-                with open(data, "rb") as datafile:
-                    files["data"] = datafile
-            # No headers; requests will add them automatically.
+        files = endpoint.get_request_body_files()
+
         return cls(target_url, headers, endpoint.method, files)
 
+@dataclass
+class FunctionLink:
+    '''Contains how functions should be mapped between modules.'''
+    from_: Endpoint | dict[str, Any]
+    to: Endpoint | dict[str, Any] | None #pylint: disable=invalid-name
+
+    def __post_init__(self):
+        """Initialize the other dataclass fields"""
+        if isinstance(self.from_, dict):
+            self.from_ = Endpoint(**self.from_)
+        if isinstance(self.to, dict):
+            self.to = Endpoint(**self.to)
+
+FunctionEndpointMap = dict[str, Endpoint]
+ModuleEndpointMap = dict[str, dict[FunctionEndpointMap]]
+"""
+Mapping of module names to functions and their endpoints. NOTE: This means that
+a deployment can not have two modules with the same name.
+"""
+
+FunctionLinkMap = dict[str, FunctionLink]
+ModuleLinkMap = dict[str, dict[FunctionLinkMap]]
 
 @dataclass
 class Deployment:
-    '''Describing a sequence of instructions to be executed in (some) order.'''
+    '''
+    Describes how (HTTP) endpoints map to environment, parameters and execution of
+    WebAssembly functions and vice versa.
+    '''
+    id: str # pylint: disable=invalid-name
     runtime: WasmRuntime
-    instructions: dict[str, dict[str, dict[str, dict[str, Any]]]]
     _modules: list[ModuleConfig]
+    endpoints: ModuleEndpointMap
+    _instructions: dict[str, Any]
     modules: dict[str, ModuleConfig] = field(init=False)
-    #main_module: WasmModule
-    '''
-    TODO: This module could in the future contain the main execution logic or
-    "script" for the _whole_ application composed of modules and distributed
-    between devices.
-    '''
+    instructions: ModuleLinkMap = field(init=False)
 
     def __post_init__(self):
         self.modules = { m.name: m for m in self._modules }
+
+        # Make the received whatever data into objects at runtime because of
+        # dynamic typing.
+        for module_id, functions in self.endpoints.items():
+            for function_name, endpoint in functions.items():
+                self.endpoints[module_id][function_name] = Endpoint(**endpoint)
+
+        # NOTE: This is what current implementation sends as instructions which
+        # might change to not have the 'module' key at all.
+        self.instructions = {}
+        for module_name, functions in self._instructions['modules'].items():
+            self.instructions[module_name] = {}
+            for function_name, link in functions.items():
+                # NOTE: The from-keyword prevents using the double splat
+                # operator for key-value initialization of this class.
+                self.instructions[module_name][function_name] = \
+                    FunctionLink(from_=link["from"], to=link["to"])
 
     def _next_target(self, module_name, function_name) -> Endpoint | None:
         '''
         Return the target where the module's function's output is to be sent next.
         '''
 
-        if (next_endpoint := self.instructions['modules'][module_name][function_name]['to']):
-            # TODO: Check if the endpoint is on this device already or not to
-            # prevent unnecessary network requests.
-            # endpoint_description = self.instructions['endpoints'][next_endpoint.function_name]
-            endpoint_description = next_endpoint
-            return Endpoint.from_openapi(endpoint_description)
+        # TODO: Check if the endpoint is on this device already or not to
+        # prevent unnecessary network requests.
+        return self.instructions[module_name][function_name].to
 
-        return None
-
-    def mounts_for(self, module: WasmModule, function_name: str) -> list[(MountPathFile, bool)]:
+    def mounts_for(self, module_id, function_name) -> dict[MountStage, Set[dict[str, str]]]:
         '''
-        Get the list of files to be mounted for the module's function and
-        whether they are mandatory or not
+        Grouped by the mount stage, get the sets of files to be mounted for the
+        module's function and whether they are mandatory or not.
         '''
-        # Get the OpenAPI description for interpreting file mounts.
-        operation = self.instructions['modules'][module.name][function_name]['from']['operation']['body']
 
         # TODO: When the component model is to be integrated, map arguments in
         # request to the interface described in .wit.
 
-        top_level_content = operation.get('requestBody', {}).get('content', {})
-        request_body_paths = (
-            MountPathFile.list_from_multipart(
-                top_level_content['multipart/form-data']
+        request: EndpointRequest = self.endpoints[module_id][function_name].request
+        if request.request_body and request.request_body.media_type == 'multipart/form-data':
+            request_body_paths = (
+                MountPathFile.list_from_multipart(
+                    request.request_body,
+                    stage=MountStage.EXECUTION
+                )
             )
-            if 'multipart/form-data' in top_level_content
+        else:
             # Only multipart/form-data is supported for file mounts.
-            else []
-        )
+            request_body_paths = []
 
         # Check that all the expected media types are supported.
         # TODO: Could be done at deployment time.
@@ -256,7 +182,7 @@ class Deployment:
                 ),
                 bool(parameter.get('required', False))
             )
-            for parameter in operation.get('parameters', [])
+            for parameter in request.parameters
             if parameter.get('in', None) == 'requestBody'
                 and parameter.get('name', '') != ''
         ]
@@ -269,21 +195,113 @@ class Deployment:
 
         # Lastly if the _response_ contains files, the matching filepaths need
         # to be made available for the module to write as well.
-        response_media_type, response_media_obj = get_main_response_content_entry(operation)
-        response_files = (
-            MountPathFile.list_from_multipart(
-                response_media_obj
+        response: EndpointResponse = self.endpoints[module_id][function_name].response
+        if response.media_type == 'multipart/form-data':
+            response_files = (
+                MountPathFile.list_from_multipart(
+                    response.response_body,
+                    stage=MountStage.OUTPUT
+                )
             )
-            if 'multipart/form-data' == response_media_type
+        else:
             # Only multipart/form-data is supported for file mounts.
-            else []
+            response_files = []
+
+        mounts = param_files + request_body_paths + response_files
+
+        # TODO: Use groupby instead of this triple-set-threat.
+        execution_stage_mount_paths: Set[str] = set(
+            filter(
+                lambda y: y[0].stage == MountStage.EXECUTION,
+                mounts
+            )
+        )
+        deployment_stage_mount_paths: Set[str] = set(
+            filter(
+                lambda y: y[0].stage == MountStage.DEPLOYMENT,
+                mounts
+            )
+        )
+        output_stage_mount_paths: Set[str] = set(
+            filter(
+                lambda y: y[0].stage == MountStage.OUTPUT,
+                mounts
+            )
         )
 
-        return param_files + request_body_paths + response_files
+        return {
+           MountStage.EXECUTION: execution_stage_mount_paths,
+           MountStage.DEPLOYMENT: deployment_stage_mount_paths,
+           MountStage.OUTPUT: output_stage_mount_paths,
+        }
+
+    def _connect_request_files_to_mounts(
+            self,
+            module: WasmModule,
+            function_name,
+            request_filepaths: dict[str, Path]
+    ) -> None:
+        """
+        Check the validity of and set up the given mounts for the module to use
+        based on files found in request.
+        """
+        mounts = self.mounts_for(module.id, function_name)
+        deployment_stage_mount_paths = mounts[MountStage.EXECUTION]
+        execution_stage_mount_paths = mounts[MountStage.EXECUTION]
+
+        # Map all kinds of file parameters (optional or required) to expected
+        # mount paths and actual files _once_.
+        # NOTE: Assuming the deployment filepaths have been handled already.
+        received_filepaths: Set[str] = set(map(lambda x: x.mount_path, deployment_stage_mount_paths))
+        for request_mount_path, temp_path in request_filepaths.items():
+            # Check that the file is expected.
+            if request_mount_path not in map(lambda x: x.mount_path, execution_stage_mount_paths):
+                raise RuntimeError(f'Unexpected input file "{request_mount_path}"')
+
+            # Check that the file is not already mapped. NOTE: This prevents
+            # overwriting deployment stage files.
+            if request_mount_path not in received_filepaths:
+                received_filepaths.add(request_mount_path)
+            else:
+                raise RuntimeError(f'Input file "{temp_path}" already mapped to "{request_mount_path}"')
+
+        # Get the paths of _required_ files.
+        required_input_mount_paths: Set[str] = set(filter(
+            lambda x: x.required,
+            deployment_stage_mount_paths | execution_stage_mount_paths
+        ))
+        # Check that required files have been correctly received. Output paths
+        # are not expected in request at all.
+        required_but_not_mounted = required_input_mount_paths - received_filepaths
+        if required_but_not_mounted:
+            raise RuntimeError(f'required input files not found:  {required_but_not_mounted}')
+
+        # Set up _all_ the files needed for this run, remapping expected mount
+        # paths to temporary paths and then moving the contents between them.
+        all_mounts = execution_stage_mount_paths | deployment_stage_mount_paths | mounts[MountStage.OUTPUT]
+        for mount in all_mounts:
+            # Search for the actual filepath in filesystem first from request
+            # (execution) and second from module config (deployment).
+            if temp_path := request_filepaths.get(
+                mount.mount_path,
+                module.get_mount(mount.mount_path)
+            ):
+                # FIXME: Importing here to avoid circular imports.
+                from host_app.flask_app.app import module_mount_path
+                host_path = module_mount_path(module.name, mount.mount_path)
+                if host_path != temp_path:
+                    with open(host_path, "wb") as mountpath:
+                        with open(temp_path, "rb") as datapath:
+                            mountpath.write(datapath.read())
+                else:
+                    print('File already at mount location:', host_path)
+            else:
+                print(f'Module expects mount "{mount.mount_path}", but it was not found in request or deployment.')
+
+
 
     def prepare_for_running(
         self,
-        app_context_module_mount_path,
         module_name,
         function_name,
         args: dict,
@@ -313,76 +331,7 @@ class Deployment:
 
         # Get the mounts described for this module for checking requirementes
         # and mapping to actual received files in this request.
-        mounts = self.mounts_for(module, function_name)
-        execution_stage_mount_paths: Set[str] = set(map(
-            lambda x: x[0].mount_path,
-            filter(
-                lambda y: y[0].stage == MountStage.EXECUTION,
-                mounts
-            )
-        ))
-        deployment_stage_mount_paths: Set[str] = set(map(
-            lambda x: x[0].mount_path,
-            filter(
-                lambda y: y[0].stage == MountStage.DEPLOYMENT,
-                mounts
-            )
-        ))
-        output_stage_mount_paths: Set[str] = set(map(
-            lambda x: x[0].mount_path,
-            filter(
-                lambda y: y[0].stage == MountStage.OUTPUT,
-                mounts
-            )
-        ))
-
-        # Map all kinds of file parameters (optional or required) to expected
-        # mount paths and actual files _once_.
-        # NOTE: Assuming the deployment filepaths have been handled already.
-        received_filepaths: Set[str] = deployment_stage_mount_paths
-        for request_mount_path, temp_path in request_filepaths.items():
-            # Check that the file is expected.
-            if request_mount_path not in execution_stage_mount_paths:
-                raise RuntimeError(f'Unexpected input file "{request_mount_path}"')
-
-            # Check that the file is not already mapped. NOTE: This prevents
-            # overwriting deployment stage files.
-            if request_mount_path not in received_filepaths:
-                received_filepaths.add(request_mount_path)
-            else:
-                raise RuntimeError(f'Input file "{temp_path}" already mapped to "{request_mount_path}"')
-
-        # Get the paths of _required_ files.
-        required_mount_paths: Set[str] = set(
-            map(
-                lambda y: y[0].mount_path,
-                filter(lambda x: x[1], mounts)
-            )
-        )
-        # Check that required files have been correctly received. Output paths
-        # are not expected in request at all.
-        required_but_not_mounted = required_mount_paths - received_filepaths - output_stage_mount_paths
-        if required_but_not_mounted:
-            raise RuntimeError(f'required input files not found:  {required_but_not_mounted}')
-
-        # Set up _all_ the files needed for this run, remapping expected mount
-        # paths to temporary paths and then moving the contents between them.
-        for mount, _required in mounts:
-            # Search for the actual filepath in filesystem first from request
-            # (execution) and second from module config (deployment).
-            if temp_path := request_filepaths.get(
-                mount.mount_path,
-                module_config.data_files.get(mount.mount_path, None)
-            ):
-                host_path = app_context_module_mount_path(module_name, mount.mount_path)
-                if host_path != temp_path:
-                    with open(host_path, "wb") as mountpath:
-                        with open(temp_path, "rb") as datapath:
-                            mountpath.write(datapath.read())
-                else:
-                    print('File already at mount location:', host_path)
-            else:
-                print(f'Module expects mount "{mount.mount_path}", but it was not found in request or deployment.')
+        self._connect_request_files_to_mounts(module, function_name, request_filepaths)
 
         return module, primitive_args
 
@@ -405,11 +354,8 @@ class Deployment:
 
         # NOTE: Assuming the actual method used was the one described in
         # deployment.
-        operation_obj = self.instructions['modules'][module_name][function_name]['from']['operation']['body']
-        response_media = get_main_response_content_entry(operation_obj)
-
         source_endpoint_result = self.parse_endpoint_result(
-            wasm_output, response_media[0], response_media[1].get('schema', {})
+            module_name, function_name, wasm_output
         )
 
         # Check if there still is stuff to do.
@@ -423,9 +369,9 @@ class Deployment:
 
     def parse_endpoint_result(
             self,
+            module_name,
+            function_name,
             func_result,
-            media_type,
-            schema
         ) -> EndpointOutput:
         '''
         Based on media type (and schema if a structure like JSON), transform given
@@ -441,74 +387,22 @@ class Deployment:
         filepath in the form of `Path` is returned.
         .
         '''
-        if media_type == 'application/json':
-            if can_be_represented_as_wasm_primitive(schema):
+
+        from_endpoint: EndpointResponse = self.instructions[module_name][function_name].from_.response
+
+        if from_endpoint.media_type == 'application/json':
+            if can_be_represented_as_wasm_primitive(from_endpoint.schema):
                 return json.dumps(func_result), None
             raise NotImplementedError('Non-primitive JSON from Wasm output not supported yet')
-        if media_type == 'image/jpeg':
-            temp_img_path = Path(schema.keys()[0])
-            return None, temp_img_path
-        raise NotImplementedError(f'Unsupported response media type "{media_type}"')
+        if from_endpoint.media_type in FILE_TYPES:
+            # The result is expected to be found in a file mounted to the module.
+            out_img_path = self.modules[module_name].get_output_path()
+            return None, out_img_path
+        raise NotImplementedError(f'Unsupported response media type "{from_endpoint.media_type}"')
 
-def assert_single_pop(iterable) -> Any | None:
-    '''
-    Assert that the iterator has only one item and return it.
-    '''
-    iterator = iter(iterable)
-    item = next(iter(iterator), None)
-    assert item and next(iterator, None) is None, 'Only one item expected'
-    return item
-
-def validate_operation(method, operation_obj) -> Tuple[str, dict[str, Any]]:
-    '''
-    Dig out the one and only one operation method and object from the OpenAPI
-    v3.1.0 path object.
-    '''
-    open_api_3_1_0_operations = set((
-        'get', 'put', 'post', 'delete',
-        'options', 'head', 'patch', 'trace'
-    ))
-    assert method in open_api_3_1_0_operations, f'bad operation method: {method}'
-
-    # TODO: Check that the operation object is valid.
-
-    return method, operation_obj
-
-def get_main_response_content_entry(operation_obj):
-    '''
-    Dig out the one and only one _response_ __media type__ and matching __media type
-    object__ from under the OpenAPI v3.1.0 operation object's content field.
-
-    NOTE: 200 is the only assumed response code.
-    '''
-    media_type_and_object = assert_single_pop(
-        operation_obj['responses']['200']['content'].items()
-    )
-    if media_type_and_object is None:
-        return "", {}
-    media_type, media_type_object = media_type_and_object
-    return media_type, media_type_object
-
-def can_be_represented_as_wasm_primitive(schema) -> bool:
+def can_be_represented_as_wasm_primitive(schema: Schema) -> bool:
     '''
     Return True if the OpenAPI schema object can be represented as a WebAssembly
     primitive.
     '''
-    type_ = schema.get('type', None)
-    return type_ == 'integer' or type_ == 'float'
-
-def get_supported_file_schemas(media_type_obj):
-    '''
-    Return iterator of tuples of (path, schema) for all fields interpretable as
-    files under multipart/form-data media type.
-    '''
-
-    return (
-        (path, schema) for path, schema in
-                media_type_obj.get('schema', {})
-                .get('properties', {})
-                .items()
-        if schema['type'] == 'string' \
-            and schema['format'] == 'binary' \
-            and media_type_obj['encoding'][path]['contentType'] in FILE_TYPES
-    )
+    return schema.type in (SchemaType.INTEGER, )

--- a/host_app/utils/endpoint.py
+++ b/host_app/utils/endpoint.py
@@ -1,0 +1,122 @@
+"""
+This module defines the Endpoint class representing (and constraining) how
+WebAssembly functions can be called via HTTP.
+
+The description mostly follows the OpenAPI v3.0 specification.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from host_app.utils import FILE_TYPES
+
+
+class SchemaType(Enum):
+    """OpenAPI v.3.0 schema type"""
+    INTEGER = 'integer'
+    STRING = 'string'
+    OBJECT = 'object'
+
+class SchemaFormat(Enum):
+    """OpenAPI v.3.0 schema format"""
+    BINARY = 'binary'
+
+@dataclass
+class Schema:
+    """JSON Schema"""
+    type: SchemaType
+    format: SchemaFormat | str | None = None
+    properties: dict[str, Any] | None = None
+
+    def __post_init__(self):
+        """Initialize the other dataclass fields"""
+        self.type = SchemaType(self.type)
+        if self.format and isinstance(self.format, str):
+            self.format = SchemaFormat(self.format)
+
+@dataclass
+class MediaTypeObject:
+    """OpenAPI v.3.0 media type object"""
+    media_type: str
+    schema: Schema | dict[str, Any]
+    encoding: dict[str, str] | None = None # propertyName/mountPath -> contentType
+
+    def __post_init__(self):
+        """Initialize the other dataclass fields"""
+        if isinstance(self.schema, dict):
+            self.schema = Schema(**self.schema)
+
+@dataclass
+class EndpointRequest:
+    """OpenAPI v.3.0 operation minus responses"""
+    parameters: list[dict[str, str | bool]]
+    request_body: MediaTypeObject | dict[str, Any] | None = None
+
+    def __post_init__(self):
+        """Initialize the other dataclass fields"""
+        if isinstance(self.request_body, dict):
+            self.request_body = MediaTypeObject(**self.request_body)
+
+EndpointResponse = MediaTypeObject
+
+@dataclass
+class Endpoint:
+    '''Describing an endpoint for a RPC-call'''
+    url: str
+    path: str
+    method: str
+    request: EndpointRequest | dict[str, Any]
+    response: EndpointResponse | dict[str, Any]
+
+    def __post_init__(self):
+        """Initialize the other dataclass fields"""
+        if isinstance(self.request, dict):
+            self.request = EndpointRequest(**self.request)
+        if isinstance(self.response, dict):
+            self.response = EndpointResponse(**self.response)
+
+    @classmethod
+    def validated(cls, obj: dict[str, Any]): # -> Endpoint
+        """Validating constructor for Endpoint"""
+        # TODO
+        return obj
+
+
+    def open_response_files(self):
+        """
+        Return mapping of mount paths (i.e. relative to module root) to
+        __opened__ files, which should be later sent forward as originated from
+        this endpoint.
+        """
+        files = {}
+        if self.response.media_type:
+            if self.response.media_type == 'multipart/form-data':
+                execution_files = list(
+                    get_supported_file_schemas(self.response.schema, self.response.encoding)
+                )
+                # Map the mount names to files created during previous Wasm
+                # call.
+                for path, _schema in execution_files:
+                    # TODO: Use schema to determine the encoding.
+                    files[path] = open(path, 'rb')
+            else:
+                raise NotImplementedError(f"Unsupported media type: {self.response.media_type}")
+            # No headers; requests will add them automatically.
+        return files
+
+
+def get_supported_file_schemas(schema: Schema, encoding):
+    '''
+    Return iterator of tuples of (path, schema) for all fields interpretable as
+    files under multipart/form-data media type.
+    '''
+
+    return (
+        (path, sub_schema) for path, sub_schema in
+                schema.properties.items()
+        if sub_schema['type'] == 'string' \
+            and sub_schema['format'] == 'binary' \
+            and encoding[path]['contentType'] in FILE_TYPES
+    )
+

--- a/host_app/utils/mount.py
+++ b/host_app/utils/mount.py
@@ -1,0 +1,69 @@
+"""
+This module describes the MountPathFile class that connects a module's data
+files and endpoint description(s) together into filepaths relative to the module.
+
+The mounts are expected at different stages: deployment, execution, and output.
+The first of these is for files that are mounted when the module is deployed and
+thus not seen in the endpoint descriptions.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from host_app.utils.endpoint import MediaTypeObject, SchemaType, get_supported_file_schemas
+
+
+class MountStage(Enum):
+    '''
+    Defines the stage at which a file is mounted.
+    '''
+    DEPLOYMENT = 'deployment'
+    EXECUTION = 'execution'
+    OUTPUT = 'output'
+
+@dataclass(eq=True, frozen=True)
+class MountPathFile:
+    '''
+    Defines the schema used for files in "multipart/form-data" requests
+    '''
+    mount_path: str
+    media_type: str
+    stage: MountStage
+    required = True
+    encoding: str = 'base64'
+    type: str = 'string'
+
+    @classmethod
+    def validate(cls, x: dict[str, Any]): # -> MountPathFile:
+        # TODO
+        return x
+
+    @classmethod
+    def list_from_multipart(cls, multipart_media_type_obj: MediaTypeObject, stage): # -> list[MountPathFile]:
+        '''
+        Extract list of files to mount when multipart/form-data is used to
+        describe a schema of multiple files.
+
+        Create a MountPathFiles from the JSON schema used in this project for
+        describing files and their paths.
+        '''
+
+        media_type = multipart_media_type_obj.media_type
+        assert media_type == 'multipart/form-data', \
+            f'Expected multipart/form-data media type, but got "{media_type}"'
+
+        schema = multipart_media_type_obj.schema
+        assert schema.type == SchemaType.OBJECT, 'Only object schemas supported'
+        assert schema.properties, 'Expected properties for multipart schema'
+
+        mounts = []
+        encoding = multipart_media_type_obj.encoding
+        for path, schema in get_supported_file_schemas(schema, encoding):
+            media_type = encoding[path]['contentType']
+            # NOTE: The other encoding field ('format') is not regarded here.
+            mount = cls(path, media_type, stage)
+            mounts.append(mount)
+
+        return mounts
+

--- a/host_app/utils/mount.py
+++ b/host_app/utils/mount.py
@@ -22,48 +22,24 @@ class MountStage(Enum):
     EXECUTION = 'execution'
     OUTPUT = 'output'
 
-@dataclass(eq=True, frozen=True)
+@dataclass
 class MountPathFile:
     '''
     Defines the schema used for files in "multipart/form-data" requests
     '''
-    mount_path: str
+    path: str
     media_type: str
-    stage: MountStage
+    stage: MountStage | str
     required = True
     encoding: str = 'base64'
     type: str = 'string'
+
+    def __post_init__(self):
+        """Initialize the other dataclass fields"""
+        if isinstance(self.stage, str):
+            self.stage = MountStage(self.stage)
 
     @classmethod
     def validate(cls, x: dict[str, Any]): # -> MountPathFile:
         # TODO
         return x
-
-    @classmethod
-    def list_from_multipart(cls, multipart_media_type_obj: MediaTypeObject, stage): # -> list[MountPathFile]:
-        '''
-        Extract list of files to mount when multipart/form-data is used to
-        describe a schema of multiple files.
-
-        Create a MountPathFiles from the JSON schema used in this project for
-        describing files and their paths.
-        '''
-
-        media_type = multipart_media_type_obj.media_type
-        assert media_type == 'multipart/form-data', \
-            f'Expected multipart/form-data media type, but got "{media_type}"'
-
-        schema = multipart_media_type_obj.schema
-        assert schema.type == SchemaType.OBJECT, 'Only object schemas supported'
-        assert schema.properties, 'Expected properties for multipart schema'
-
-        mounts = []
-        encoding = multipart_media_type_obj.encoding
-        for path, schema in get_supported_file_schemas(schema, encoding):
-            media_type = encoding[path]['contentType']
-            # NOTE: The other encoding field ('format') is not regarded here.
-            mount = cls(path, media_type, stage)
-            mounts.append(mount)
-
-        return mounts
-

--- a/host_app/wasm_utils/wasm3.py
+++ b/host_app/wasm_utils/wasm3.py
@@ -7,7 +7,7 @@ import wasm3
 
 from host_app.wasm_utils.general_utils import (
     python_clock_ms, python_delay, python_print_int, python_println, python_get_temperature,
-    python_get_humidity, Print, TakeImage, RpcCall, RandomGet
+    python_get_humidity, Print, TakeImageDynamicSize, RpcCall, RandomGet
 )
 from host_app.wasm_utils.wasm_api import (
     WasmRuntime, WasmModule, ModuleConfig, WasmRuntimeNotSetError
@@ -183,7 +183,7 @@ class Wasm3Module(WasmModule):
         self._instance.link_function(communication, "rpcCall", "v(*iii)", rpc_call)
 
         # peripheral
-        self._instance.link_function(camera, "takeImage", "v(*i)", TakeImage(self.runtime).function)
+        self._instance.link_function(camera, "takeImage", "v(*i)", TakeImageDynamicSize(self.runtime).function)
         self._instance.link_function(dht, "getTemperature", "f()", python_get_temperature)
         self._instance.link_function(dht, "getHumidity", "f()", python_get_humidity)
 

--- a/host_app/wasm_utils/wasm_api.py
+++ b/host_app/wasm_utils/wasm_api.py
@@ -1,9 +1,10 @@
 """General interface for Wasm utilities."""
 
 from __future__ import annotations
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeAlias
+
 
 ByteType: TypeAlias = bytes | bytearray
 
@@ -262,15 +263,23 @@ class WasmModule:
         """Link the remote functions to the Wasm module."""
         raise NotImplementedError
 
+ModuleDescription = dict[str, Any]
+"""
+Describes how a module exposes its functions as remote services. Based on
+OpenAPI.
+"""
 
 @dataclass
 class ModuleConfig:
-    """Dataclass for module name and file location."""
+    """
+    Dataclass for module name, file location and associated files referred to as
+    'mounts'. This is what a module instance for running functions is created
+    based on.
+    """
     id: str  # pylint: disable=invalid-name
     name: str
     path: str
-    description: Any = field(default_factory=dict)
-    data_files: Dict[str, Path] = field(default_factory=dict)
+    data_files: dict[str, Path]
     ml_model: Optional[MLModel] = None
     data_ptr_function_name: str = "get_img_ptr"
 
@@ -278,6 +287,7 @@ class ModuleConfig:
         """Sets the model using the indicated data file."""
         if key in self.data_files:
             self.ml_model = MLModel(str(self.data_files[key]))
+
 
 
 @dataclass

--- a/host_app/wasm_utils/wasm_api.py
+++ b/host_app/wasm_utils/wasm_api.py
@@ -270,14 +270,14 @@ class ModuleConfig:
     name: str
     path: str
     description: Any = field(default_factory=dict)
-    data_files: List[Path] = field(default_factory=list)
+    data_files: Dict[str, Path] = field(default_factory=dict)
     ml_model: Optional[MLModel] = None
     data_ptr_function_name: str = "get_img_ptr"
 
-    def set_model_from_data_files(self, index: int = 0) -> None:
+    def set_model_from_data_files(self, key: str = "model.pb") -> None:
         """Sets the model using the indicated data file."""
-        if 0 <= index < len(self.data_files):
-            self.ml_model = MLModel(str(self.data_files[index]))
+        if key in self.data_files:
+            self.ml_model = MLModel(str(self.data_files[key]))
 
 
 @dataclass

--- a/host_app/wasm_utils/wasmtime.py
+++ b/host_app/wasm_utils/wasmtime.py
@@ -31,7 +31,7 @@ class WasmtimeRuntime(WasmRuntime):
         self._wasi = WasiConfig()
         self._wasi.inherit_stdout()
         self._wasi.inherit_env()
-        # Open directories for the modules to access at their root(?)
+        # Open directories for the module to access at its root.
         for data_dir in data_dirs:
             guest_dir = "."
             print(f"Mounting {data_dir} to {guest_dir}")

--- a/host_app/wasm_utils/wasmtime.py
+++ b/host_app/wasm_utils/wasmtime.py
@@ -11,7 +11,7 @@ from wasmtime import (
 
 from host_app.wasm_utils.general_utils import (
     python_clock_ms, python_delay, python_print_int, python_println, python_get_temperature,
-    python_get_humidity, Print, TakeImage, RpcCall
+    python_get_humidity, Print, TakeImageDynamicSize, TakeImageStaticSize, RpcCall
 )
 from host_app.wasm_utils.wasm_api import (
     WasmRuntime, WasmModule, ModuleConfig, IncompatibleWasmModule
@@ -167,8 +167,10 @@ class WasmtimeRuntime(WasmRuntime):
         self.linker.define_func(communication, "rpcCall", FuncType([i32, i32, i32, i32], []), rpc_call)
 
         # peripheral
-        take_image = TakeImage(self).function
-        self.linker.define_func(camera, "takeImage", FuncType([i32, i32], []), take_image)
+        take_image_dynamic_size = TakeImageDynamicSize(self).function
+        take_image_static_size = TakeImageStaticSize(self).function
+        self.linker.define_func(camera, "takeImageDynamicSize", FuncType([i32, i32], []), take_image_dynamic_size)
+        self.linker.define_func(camera, "takeImageStaticSize", FuncType([i32, i32], []), take_image_static_size)
         self.linker.define_func(dht, "getTemperature", FuncType([], [f32]), python_get_temperature)
         self.linker.define_func(dht, "getHumidity", FuncType([], [f32]), python_get_humidity)
 


### PR DESCRIPTION
This is a bit of a doozy ... again. 
- Directs files as output as well as input (which was done previously).
  - This required changing the camera API and is thus __dependent on equivalent change in wasmiot-modules!__
- Changes manifest format expected from orchestrator in order to separate module descriptions and what the deployment is really interested about.
  - Idea is to have the orchestrator do most of the work for supervisor in searching for what and which Wasm-function takes as in- and outputs.
- More classes equals more readable question mark